### PR TITLE
do not abort in CAC & PESCA server error, more friendly to users

### DIFF
--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -367,7 +367,7 @@ sub json_request {
                 ."$error->{'message'} ($error->{'code'}/$error->{'response'})";
         }
 
-	print( STDERR "  Error on the remote EPG API call\n" )  if( $opt->{quiet} );
+	print( STDERR " Error on the remote EPG API call\n" )  if( $opt->{quiet} );
 	print( STDERR $msg . "\n" )  if( $opt->{debug} );
 
 	return JSON->new->utf8(1)->decode('{"data": [] }');

--- a/grab/pt_vodafone/tv_grab_pt_vodafone
+++ b/grab/pt_vodafone/tv_grab_pt_vodafone
@@ -266,8 +266,9 @@ sub get_epg
             if ( ! $epgSource ){
                 die("Bad EPG download, probably channel list is outdated, rerun the grabber configure to update the list.\n" ); }
             elsif ( $epgSource->{data}->@* == 0 ){
-                die("Empty EPG download, probably channel list is outdated or no API data for that channel\n" .
-		    "Rerun the grabber configure to update the list or check for the channel EPG in the Vodafone app.\n" );
+                print( STDERR " Empty EPG download for ".$channel.", probably channel list is outdated or no API data for that channel\n" .
+		    "  Rerun the grabber configure to update the list or check for the channel EPG in the Vodafone app.\n" );
+		next;
             };
 
             my $data = $epgSource->{data};
@@ -366,7 +367,10 @@ sub json_request {
                 ."$error->{'message'} ($error->{'code'}/$error->{'response'})";
         }
 
-        die $msg, "\n";
+	print( STDERR "  Error on the remote EPG API call\n" )  if( $opt->{quiet} );
+	print( STDERR $msg . "\n" )  if( $opt->{debug} );
+
+	return JSON->new->utf8(1)->decode('{"data": [] }');
     }
 }
 


### PR DESCRIPTION
As vodafone API still crashes with "CAC & PESCA", lets not abort on remote error, being more friendly for end users. Side effect is that renamed channels will stop failing and simply return empty.